### PR TITLE
Allow get parameters in image URL pattern

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,7 +269,7 @@ class SimpleImage {
   static get pasteConfig() {
     return {
       patterns: {
-        image: /https?:\/\/\S+\.(gif|jpe?g|tiff|png)$/i
+        image: /https?:\/\/\S+\.(gif|jpe?g|tiff|png)(\?[^?]+|$)/i
       },
       tags: [ 'img' ],
       files: {


### PR DESCRIPTION
Image URLs with GET parameters are pretty common occurrence, especially with services like imgix.