### PR TITLE
data.url cache bug changes the value internally on 3rd save() call triggered with editor.js.save()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,7 @@ class SimpleImage {
     }
 
     return Object.assign(this.data, {
-      url: image.src,
+      url:  this.data.url, 
       caption: caption.innerHTML,
     });
   }


### PR DESCRIPTION
//image.src is not reliable, this was tracked using the editorjs-undo plugin in bigBrother mode

If you add  before the return line this code
```js
  var strWindowFeatures = "location=no,height=570,width=800,scrollbars=yes,status=yes";
    var childWindow= window.open('', "_blank", strWindowFeatures);
    childWindow.document.write("<pre>"+JSON.stringify(this.data, null, 4 ) +"</pre>");
    childWindow.focus();
```
You will see that starting the 3rd click on editor.js.save() button from editor.js/src/editor.js/example/example-dev.html
 that the relative image path 'assets/codex2x.png' is being converted to http url  such as http://localhost/editor.js/src/editor.js/example/assets/codex2x.png",
this will be taken as a change and polluate  the undo plugin